### PR TITLE
Remove unnecessary strings.xml file

### DIFF
--- a/aes-crypto/src/main/res/values/strings.xml
+++ b/aes-crypto/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Aes-crypto</string>
-</resources>


### PR DESCRIPTION
This resource is not referenced anywhere, and it is generally unnecessary for libraries to have an app_name anyway.
