### PR TITLE
making fixPrng public

### DIFF
--- a/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
+++ b/aes-crypto/src/main/java/com/tozny/crypto/android/AesCbcWithIntegrity.java
@@ -340,7 +340,7 @@ public class AesCbcWithIntegrity {
      * Ensures that the PRNG is fixed. Should be used before generating any keys.
      * Will only run once, and every subsequent call should return immediately.
      */
-    private static void fixPrng() {
+    public static void fixPrng() {
         if (!prngFixed.get()) {
             synchronized (PrngFixes.class) {
                 if (!prngFixed.get()) {


### PR DESCRIPTION
### Description
- making the fixPrng method public so we can use SecureRandom outside of this library